### PR TITLE
set country type default to NULL

### DIFF
--- a/country--0.0.1--0.0.2.sql
+++ b/country--0.0.1--0.0.2.sql
@@ -1,0 +1,8 @@
+UPDATE pg_catalog.pg_type typ
+    SET typdefault=NULL
+FROM pg_catalog.pg_extension ext,
+pg_depend dep
+WHERE dep.refobjid = ext.oid
+AND dep.objid = typ.oid
+AND ext.extname='country'
+AND typ.typname='country';

--- a/country--0.0.2--0.0.1.sql
+++ b/country--0.0.2--0.0.1.sql
@@ -1,0 +1,8 @@
+UPDATE pg_catalog.pg_type typ
+    SET typdefault=''
+FROM pg_catalog.pg_extension ext,
+pg_depend dep
+WHERE dep.refobjid = ext.oid
+AND dep.objid = typ.oid
+AND ext.extname='country'
+AND typ.typname='country';

--- a/country--0.0.2.sql
+++ b/country--0.0.2.sql
@@ -1,3 +1,6 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION country" to load this file. \quit
+--source file sql/country.sql
 CREATE FUNCTION country_in(cstring)
 RETURNS country
 AS '$libdir/country'
@@ -29,28 +32,28 @@ CREATE TYPE country (
 COMMENT ON TYPE country IS 'a country internaly stored as int8';
 
 CREATE FUNCTION country_eq(country, country)
-RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'chareq';
+RETURNS boolean LANGUAGE internal IMMUTABLE AS 'chareq';
 
 CREATE FUNCTION country_ne(country, country)
-RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charne';
+RETURNS boolean LANGUAGE internal IMMUTABLE AS 'charne';
 
 CREATE FUNCTION country_lt(country, country)
-RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charlt';
+RETURNS boolean LANGUAGE internal IMMUTABLE AS 'charlt';
 
 CREATE FUNCTION country_le(country, country)
-RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charle';
+RETURNS boolean LANGUAGE internal IMMUTABLE AS 'charle';
 
 CREATE FUNCTION country_gt(country, country)
-RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'chargt';
+RETURNS boolean LANGUAGE internal IMMUTABLE AS 'chargt';
 
 CREATE FUNCTION country_ge(country, country)
-RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charge';
+RETURNS boolean LANGUAGE internal IMMUTABLE AS 'charge';
 
 CREATE FUNCTION country_cmp(country, country)
-RETURNS integer LANGUAGE internal IMMUTABLE STRICT AS 'btcharcmp';
+RETURNS integer LANGUAGE internal IMMUTABLE AS 'btcharcmp';
 
 CREATE FUNCTION hash_country(country)
-RETURNS integer LANGUAGE internal IMMUTABLE STRICT AS 'hashchar';
+RETURNS integer LANGUAGE internal IMMUTABLE AS 'hashchar';
 
 CREATE OPERATOR = (
 	LEFTARG = country,
@@ -80,7 +83,7 @@ CREATE OPERATOR < (
 	PROCEDURE = country_lt,
 	COMMUTATOR = > ,
 	NEGATOR = >= ,
- 	RESTRICT = scalarltsel,
+   	RESTRICT = scalarltsel,
 	JOIN = scalarltjoinsel
 );
 COMMENT ON OPERATOR <(country, country) IS 'less-than';
@@ -91,7 +94,7 @@ CREATE OPERATOR <= (
 	PROCEDURE = country_le,
 	COMMUTATOR = >= ,
 	NEGATOR = > ,
-  RESTRICT = scalarltsel,
+   	RESTRICT = scalarltsel,
 	JOIN = scalarltjoinsel
 );
 COMMENT ON OPERATOR <=(country, country) IS 'less-than-or-equal';
@@ -102,7 +105,7 @@ CREATE OPERATOR > (
 	PROCEDURE = country_gt,
 	COMMUTATOR = < ,
 	NEGATOR = <= ,
-  RESTRICT = scalargtsel,
+   	RESTRICT = scalargtsel,
 	JOIN = scalargtjoinsel
 );
 COMMENT ON OPERATOR >(country, country) IS 'greater-than';
@@ -113,7 +116,7 @@ CREATE OPERATOR >= (
 	PROCEDURE = country_ge,
 	COMMUTATOR = <= ,
 	NEGATOR = < ,
-  RESTRICT = scalargtsel,
+   	RESTRICT = scalargtsel,
 	JOIN = scalargtjoinsel
 );
 COMMENT ON OPERATOR >=(country, country) IS 'greater-than-or-equal';
@@ -121,15 +124,15 @@ COMMENT ON OPERATOR >=(country, country) IS 'greater-than-or-equal';
 CREATE OPERATOR CLASS btree_country_ops
 DEFAULT FOR TYPE country USING btree
 AS
-  OPERATOR        1       <  ,
-  OPERATOR        2       <= ,
-  OPERATOR        3       =  ,
-  OPERATOR        4       >= ,
-  OPERATOR        5       >  ,
-  FUNCTION        1       country_cmp(country, country);
+        OPERATOR        1       <  ,
+        OPERATOR        2       <= ,
+        OPERATOR        3       =  ,
+        OPERATOR        4       >= ,
+        OPERATOR        5       >  ,
+        FUNCTION        1       country_cmp(country, country);
 
 CREATE OPERATOR CLASS hash_country_ops
-DEFAULT FOR TYPE country USING hash
-AS
-  OPERATOR        1       = ,
-  FUNCTION        1       hash_country(country);
+    DEFAULT FOR TYPE country USING hash AS
+        OPERATOR        1       = ,
+        FUNCTION        1       hash_country(country);
+ 

--- a/country.control
+++ b/country.control
@@ -1,5 +1,5 @@
-        # country extension
-        comment = 'my awesome extension'
-        default_version = '0.0.1'
-        relocatable = true
-        requires = ''
+# country extension
+comment = 'my awesome extension'
+default_version = '0.0.2'
+relocatable = true
+requires = ''

--- a/spec/binary_copy_spec.rb
+++ b/spec/binary_copy_spec.rb
@@ -7,7 +7,7 @@ describe 'binary_copy' do
 
   it "should copy data binary from country" do
     query("CREATE TABLE before (a country)")
-    query("INSERT INTO before values ('de'),('us'),('es'),('de'),('zz')")
+    query("INSERT INTO before values ('de'),('us'),('es'),(NULL),('de'),('zz')")
     query("CREATE TABLE after (a country)")
     query("COPY before TO '/tmp/tst' WITH (FORMAT binary)")
     query("COPY after FROM '/tmp/tst' WITH (FORMAT binary)")
@@ -15,6 +15,7 @@ describe 'binary_copy' do
       ['de'],
       ['us'],
       ['es'],
+      [nil],
       ['de'],
       ['zz']
   end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -7,6 +7,7 @@ describe 'persistence' do
 
   it 'should persist countries' do
     query("CREATE TABLE country_test AS SELECT 'de'::country, 1 as num")
+    query("INSERT INTO country_test(num) VALUES(3);")
     query("SELECT * FROM country_test").should match  'de',  1
     query("UPDATE country_test SET num = 2")
     query("SELECT * FROM country_test").should match  'de',  2

--- a/test/expected/binary_copy_test.out
+++ b/test/expected/binary_copy_test.out
@@ -3,7 +3,7 @@ BEGIN;
 -- ./spec/binary_copy_spec.rb:8;
 CREATE EXTENSION country;
 CREATE TABLE before (a country);
-INSERT INTO before values ('de'),('us'),('es'),('de'),('zz');
+INSERT INTO before values ('de'),('us'),('es'),(NULL),('de'),('zz');
 CREATE TABLE after (a country);
 COPY before TO '/tmp/tst' WITH (FORMAT binary);
 COPY after FROM '/tmp/tst' WITH (FORMAT binary);
@@ -13,8 +13,9 @@ SELECT * FROM after;
  de
  us
  es
+ 
  de
  zz
-(5 rows)
+(6 rows)
 
 ROLLBACK;

--- a/test/expected/country_pass_test.out
+++ b/test/expected/country_pass_test.out
@@ -2,6 +2,12 @@ BEGIN;
 -- country_pass should pass valid countries;
 -- ./spec/country_pass_spec.rb:34;
 CREATE EXTENSION country;
+SELECT NULL::country;
+ country 
+---------
+ 
+(1 row)
+
 SELECT 'ad'::country;
  country 
 ---------

--- a/test/expected/persistence_test.out
+++ b/test/expected/persistence_test.out
@@ -3,17 +3,20 @@ BEGIN;
 -- ./spec/persistence_spec.rb:8;
 CREATE EXTENSION country;
 CREATE TABLE country_test AS SELECT 'de'::country, 1 as num;
+INSERT INTO country_test(num) VALUES(3);
 SELECT * FROM country_test;
  country | num 
 ---------+-----
  de      |   1
-(1 row)
+         |   3
+(2 rows)
 
 UPDATE country_test SET num = 2;
 SELECT * FROM country_test;
  country | num 
 ---------+-----
  de      |   2
-(1 row)
+         |   2
+(2 rows)
 
 ROLLBACK;

--- a/test/sql/binary_copy_test.sql
+++ b/test/sql/binary_copy_test.sql
@@ -3,7 +3,7 @@ BEGIN;
 -- ./spec/binary_copy_spec.rb:8;
 CREATE EXTENSION country;
 CREATE TABLE before (a country);
-INSERT INTO before values ('de'),('us'),('es'),('de'),('zz');
+INSERT INTO before values ('de'),('us'),('es'),(NULL),('de'),('zz');
 CREATE TABLE after (a country);
 COPY before TO '/tmp/tst' WITH (FORMAT binary);
 COPY after FROM '/tmp/tst' WITH (FORMAT binary);

--- a/test/sql/country_pass_test.sql
+++ b/test/sql/country_pass_test.sql
@@ -2,6 +2,7 @@ BEGIN;
 -- country_pass should pass valid countries;
 -- ./spec/country_pass_spec.rb:34;
 CREATE EXTENSION country;
+SELECT NULL::country;
 SELECT 'ad'::country;
 SELECT 'ae'::country;
 SELECT 'af'::country;

--- a/test/sql/persistence_test.sql
+++ b/test/sql/persistence_test.sql
@@ -3,6 +3,7 @@ BEGIN;
 -- ./spec/persistence_spec.rb:8;
 CREATE EXTENSION country;
 CREATE TABLE country_test AS SELECT 'de'::country, 1 as num;
+INSERT INTO country_test(num) VALUES(3);
 SELECT * FROM country_test;
 UPDATE country_test SET num = 2;
 SELECT * FROM country_test;


### PR DESCRIPTION
primarily the country type default value was set to '' (empty string)
which actually isn't a valid country string representation and would
lead to `ERROR:  invalid country input string`
setting the default to the reasonable value 'zz' would result in
a useless complete table rewrite on alter table add column ...
for nullable input thus we use the widely used default null.
Note: there is no ALTER TYPE command available to change the default value,
thus we need to update pg_type directly in the migration file.