### PR TITLE
Add cast functions to and from int2 and int4 types

### DIFF
--- a/country--0.0.4--0.0.5.sql
+++ b/country--0.0.4--0.0.5.sql
@@ -1,0 +1,44 @@
+CREATE FUNCTION int4_to_country(int4)
+RETURNS country
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_to_int4(country)
+RETURNS int4
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION int2_to_country(int2)
+RETURNS country
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_to_int2(country)
+RETURNS int2
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+DO $$
+DECLARE version_num integer;
+BEGIN
+  SELECT current_setting('server_version_num') INTO STRICT version_num;
+  IF version_num > 90600 THEN
+    ALTER FUNCTION int4_to_country(int4) PARALLEL SAFE;
+    ALTER FUNCTION country_to_int4(country) PARALLEL SAFE;
+    ALTER FUNCTION int2_to_country(int2) PARALLEL SAFE;
+    ALTER FUNCTION country_to_int2(country) PARALLEL SAFE;
+  END IF;
+END;
+$$;
+
+CREATE CAST (int4 as country)
+WITH FUNCTION int4_to_country(int4);
+
+CREATE CAST (country as int4)
+WITH FUNCTION country_to_int4(country);
+
+CREATE CAST (int2 as country)
+WITH FUNCTION int2_to_country(int2);
+
+CREATE CAST (country as int2)
+WITH FUNCTION country_to_int2(country);

--- a/country--0.0.5.sql
+++ b/country--0.0.5.sql
@@ -1,0 +1,205 @@
+CREATE FUNCTION country_in(cstring)
+RETURNS country
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_out(country)
+RETURNS cstring
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_recv(internal)
+RETURNS country
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_send(country)
+RETURNS bytea
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE TYPE country (
+    INPUT          = country_in,
+    OUTPUT         = country_out,
+    RECEIVE        = country_recv,
+    SEND           = country_send,
+    LIKE           = "char",
+    CATEGORY       = 'S'
+);
+COMMENT ON TYPE country IS 'a country internaly stored as int8';
+
+
+CREATE FUNCTION country_name(country)
+RETURNS TEXT
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_common_name(country)
+RETURNS TEXT
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION int4_to_country(int4)
+RETURNS country
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_to_int4(country)
+RETURNS int4
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION int2_to_country(int2)
+RETURNS country
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_to_int2(country)
+RETURNS int2
+AS '$libdir/country'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION country_eq(country, country)
+RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'chareq';
+
+CREATE FUNCTION country_ne(country, country)
+RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charne';
+
+CREATE FUNCTION country_lt(country, country)
+RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charlt';
+
+CREATE FUNCTION country_le(country, country)
+RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charle';
+
+CREATE FUNCTION country_gt(country, country)
+RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'chargt';
+
+CREATE FUNCTION country_ge(country, country)
+RETURNS boolean LANGUAGE internal IMMUTABLE STRICT AS 'charge';
+
+CREATE FUNCTION country_cmp(country, country)
+RETURNS integer LANGUAGE internal IMMUTABLE STRICT AS 'btcharcmp';
+
+CREATE FUNCTION hash_country(country)
+RETURNS integer LANGUAGE internal IMMUTABLE STRICT AS 'hashchar';
+
+DO $$
+DECLARE version_num integer;
+BEGIN
+  SELECT current_setting('server_version_num') INTO STRICT version_num;
+  IF version_num > 90600 THEN
+    ALTER FUNCTION country_in(cstring) PARALLEL SAFE;
+    ALTER FUNCTION country_out(country) PARALLEL SAFE;
+    ALTER FUNCTION country_recv(internal) PARALLEL SAFE;
+    ALTER FUNCTION country_send(country) PARALLEL SAFE;
+    ALTER FUNCTION country_name(country) PARALLEL SAFE;
+    ALTER FUNCTION country_common_name(country) PARALLEL SAFE;
+    ALTER FUNCTION int4_to_country(int4) PARALLEL SAFE;
+    ALTER FUNCTION country_to_int4(country) PARALLEL SAFE;
+    ALTER FUNCTION int2_to_country(int2) PARALLEL SAFE;
+    ALTER FUNCTION country_to_int2(country) PARALLEL SAFE;
+    ALTER FUNCTION country_eq(country, country) PARALLEL SAFE;
+    ALTER FUNCTION country_ne(country, country) PARALLEL SAFE;
+    ALTER FUNCTION country_lt(country, country) PARALLEL SAFE;
+    ALTER FUNCTION country_le(country, country) PARALLEL SAFE;
+    ALTER FUNCTION country_gt(country, country) PARALLEL SAFE;
+    ALTER FUNCTION country_ge(country, country) PARALLEL SAFE;
+    ALTER FUNCTION country_cmp(country, country) PARALLEL SAFE;
+    ALTER FUNCTION hash_country(country) PARALLEL SAFE;
+  END IF;
+END;
+$$;
+
+CREATE OPERATOR = (
+    LEFTARG = country,
+    RIGHTARG = country,
+    PROCEDURE = country_eq,
+    COMMUTATOR = '=',
+    NEGATOR = '<>',
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);
+COMMENT ON OPERATOR =(country, country) IS 'equals?';
+
+CREATE OPERATOR <> (
+    LEFTARG = country,
+    RIGHTARG = country,
+    PROCEDURE = country_ne,
+    COMMUTATOR = '<>',
+    NEGATOR = '=',
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+COMMENT ON OPERATOR <>(country, country) IS 'not equals?';
+
+CREATE OPERATOR < (
+    LEFTARG = country,
+    RIGHTARG = country,
+    PROCEDURE = country_lt,
+    COMMUTATOR = > ,
+    NEGATOR = >= ,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+COMMENT ON OPERATOR <(country, country) IS 'less-than';
+
+CREATE OPERATOR <= (
+    LEFTARG = country,
+    RIGHTARG = country,
+    PROCEDURE = country_le,
+    COMMUTATOR = >= ,
+    NEGATOR = > ,
+  RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+COMMENT ON OPERATOR <=(country, country) IS 'less-than-or-equal';
+
+CREATE OPERATOR > (
+    LEFTARG = country,
+    RIGHTARG = country,
+    PROCEDURE = country_gt,
+    COMMUTATOR = < ,
+    NEGATOR = <= ,
+  RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+COMMENT ON OPERATOR >(country, country) IS 'greater-than';
+
+CREATE OPERATOR >= (
+    LEFTARG = country,
+    RIGHTARG = country,
+    PROCEDURE = country_ge,
+    COMMUTATOR = <= ,
+    NEGATOR = < ,
+  RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+COMMENT ON OPERATOR >=(country, country) IS 'greater-than-or-equal';
+
+CREATE OPERATOR CLASS btree_country_ops
+DEFAULT FOR TYPE country USING btree
+AS
+  OPERATOR        1       <  ,
+  OPERATOR        2       <= ,
+  OPERATOR        3       =  ,
+  OPERATOR        4       >= ,
+  OPERATOR        5       >  ,
+  FUNCTION        1       country_cmp(country, country);
+
+CREATE OPERATOR CLASS hash_country_ops
+DEFAULT FOR TYPE country USING hash
+AS
+  OPERATOR        1       = ,
+  FUNCTION        1       hash_country(country);
+
+CREATE CAST (int4 as country)
+WITH FUNCTION int4_to_country(int4);
+
+CREATE CAST (country as int4)
+WITH FUNCTION country_to_int4(country);
+
+CREATE CAST (int2 as country)
+WITH FUNCTION int2_to_country(int2);
+
+CREATE CAST (country as int2)
+WITH FUNCTION country_to_int2(country);

--- a/country.control
+++ b/country.control
@@ -1,5 +1,5 @@
 # country extension
 comment = 'my awesome extension'
-default_version = '0.0.4'
+default_version = '0.0.5'
 relocatable = true
 requires = ''

--- a/src/country.c
+++ b/src/country.c
@@ -866,3 +866,37 @@ Datum country_common_name(PG_FUNCTION_ARGS)
     country c = PG_GETARG_UINT8(0);
     PG_RETURN_TEXT_P(country_to_common_name(c));
 }
+
+PG_FUNCTION_INFO_V1(int4_to_country);
+Datum int4_to_country(PG_FUNCTION_ARGS)
+{
+    country c = PG_GETARG_INT32(0);
+
+    /* XXX we do not check input validity for performance reasons */
+    PG_RETURN_UINT8(c);
+}
+
+PG_FUNCTION_INFO_V1(country_to_int4);
+Datum country_to_int4(PG_FUNCTION_ARGS)
+{
+    country c = PG_GETARG_UINT8(0);
+
+    PG_RETURN_INT32(c);
+}
+
+PG_FUNCTION_INFO_V1(int2_to_country);
+Datum int2_to_country(PG_FUNCTION_ARGS)
+{
+    country c = PG_GETARG_INT16(0);
+
+    /* XXX we do not check input validity for performance reasons */
+    PG_RETURN_UINT8(c);
+}
+
+PG_FUNCTION_INFO_V1(country_to_int2);
+Datum country_to_int2(PG_FUNCTION_ARGS)
+{
+    country c = PG_GETARG_UINT8(0);
+
+    PG_RETURN_INT16(c);
+}

--- a/test/expected/country_cast.out
+++ b/test/expected/country_cast.out
@@ -1,0 +1,27 @@
+BEGIN;
+CREATE EXTENSION country;
+SELECT 'de'::country::int4;
+ int4 
+------
+   57
+(1 row)
+
+SELECT 'de'::country::int2;
+ int2 
+------
+   57
+(1 row)
+
+SELECT 57::int4::country;
+ country 
+---------
+ de
+(1 row)
+
+SELECT 57::int2::country;
+ country 
+---------
+ de
+(1 row)
+
+ROLLBACK;

--- a/test/sql/country_cast.sql
+++ b/test/sql/country_cast.sql
@@ -1,0 +1,7 @@
+BEGIN;
+CREATE EXTENSION country;
+SELECT 'de'::country::int4;
+SELECT 'de'::country::int2;
+SELECT 57::int4::country;
+SELECT 57::int2::country;
+ROLLBACK;


### PR DESCRIPTION
This is useful when exporting or importing data from or to external formats (i.e. Apache Parquet).